### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/arch_package.yml
+++ b/.github/workflows/arch_package.yml
@@ -1,4 +1,6 @@
 name: arch_package
+permissions:
+  contents: write
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/Ven0m0/hyfetch/security/code-scanning/1](https://github.com/Ven0m0/hyfetch/security/code-scanning/1)

To fix this issue, we need to explicitly add a `permissions` block to the workflow, either at the top level or as part of the `build` job. The most future-proof and clear approach is to add it at the root of the workflow, so that all jobs—current and future—inherit these settings, unless specifically overridden. In this workflow, uploading release assets requires `contents: write` permissions (to update the release with binaries), and all other steps can be completed with `contents: read`. No other special permissions (such as `issues` or `pull-requests`) are required. Thus, set `permissions: contents: write` at the root of the workflow, at line 2, consistently with YAML structure and indentation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
