### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Codeflash.yml
+++ b/.github/workflows/Codeflash.yml
@@ -1,4 +1,6 @@
 name: Codeflash
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Ven0m0/hyfetch/security/code-scanning/5](https://github.com/Ven0m0/hyfetch/security/code-scanning/5)

The problem should be fixed by adding an explicit `permissions` block setting the minimum required access for this workflow/job. For workflows that just check out code and run local analysis or tests (as here), `contents: read` is generally sufficient. 

From best practice, place the `permissions` block at the root level—immediately below the workflow `name` and above the `on` section—so it will apply to all jobs (unless a job specifies its own `permissions`). If the workflow adds steps that need more permissions later, this block can be adjusted. Here, add:

```yaml
permissions:
  contents: read
```

immediately following the `name:` line and before `on:`.

No extra imports or definitions are needed. Only the addition of the explicit permissions block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
